### PR TITLE
Override :slant for font-lock-comment-delimiter-face

### DIFF
--- a/graphene-meta-theme.el
+++ b/graphene-meta-theme.el
@@ -110,6 +110,8 @@
 
  `(font-lock-comment-face
    ((t (:slant normal))))
+ `(font-lock-comment-delimiter-face
+   ((t (:slant normal))))
 
  `(font-lock-doc-face
    ((t (:slant normal))))


### PR DESCRIPTION
Comment delimiters are italicised in some themes while comments themselves aren't. (This might be by design.)
